### PR TITLE
Enable FSDP and Update Loss Calculation to PPO Style

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -214,6 +214,12 @@ class GRPOConfig(TrainingArguments):
         default=0.04,
         metadata={"help": "KL coefficient."},
     )
+
+    cliprange: float = field(
+        default=0.2,
+        metadata={"help": "Clipping used in the GRPO loss function."},
+    )
+
     reward_weights: Optional[list[float]] = field(
         default=None,
         metadata={


### PR DESCRIPTION
# What does this PR do?


Fixes # (issue)


This PR does the following two things
1. Enables FSDP by making fixes in two places i) properly wraps the `ref_model` with FSDP, and ii) [accelerate.utils.other.extract_model_from_parallel](https://github.com/huggingface/accelerate/blob/8039158d71418e4520113e43bfe3567ffeedd7db/src/accelerate/utils/other.py#L100) will wrongly unwrap the top-level FSDP wrapper, and apply a patch to stop that.
2. Update loss calculation style to[ PPO regularization ](https://spinningup.openai.com/en/latest/algorithms/ppo.html)as per the GRPO paper. We follow the [implementation in TinyZero](https://github.com/Jiayi-Pan/TinyZero/blob/8a623926012ff785f2dc6f3639a821465eed07c4/verl/trainer/ppo/core_algos.py#L189), where we compute `pg_losses` and `pg_losses2`, where `pg_losses` is the equivalently to the presently implmented loss, and `pg_losses2` is the clamped loss, and where we take the final loss to be `torch.min(pg_losses, pg_losses2)`.

The issue with `extract_model_from_parallel` is that if you unwrap the top-level FSDP wrapper, then the sharded parameters handled by this wrapper will not be unwrapped properly and we get size mismatch errors. 

For the loss, what is abit confusing is that we can see in the forward pass, we must have `pg_losses == pg_losses2`. This is because since
```python
ratio = torch.exp(per_token_logps - per_token_logps.detach())
```
we always have `ratio` to always have `1.0` as its elements, and thus `torch.clamp(ratio, 1.0 - self.args.cliprange, 1.0 + self.args.cliprange) == ratio == torch.ones(...)`.  This is highly unintuitive, as it seems like since the loss is unmodified, why should the clamping matter. The key realization is while the forward is unaffected, the backward is affected, and the gradients passed backward through the ops `torch.clamp` and `torch.min` will provide the regularisation effect.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/trl/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/trl/tree/main/docs).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.