### PR TITLE
Switch to VLLM External Launcher

### DIFF
--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -207,6 +207,12 @@ class GRPOConfig(TrainingArguments):
             "help": "If not set, will default to per_device_train_batch_size * TP."
         },
     )
+    vllm_num_gpu_blocks_override: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "overide the number of gpu blocks"
+        },
+    )
 
     # Parameters that control the training
     learning_rate: float = field(

--- a/trl/trainer/grpo_config.py
+++ b/trl/trainer/grpo_config.py
@@ -201,6 +201,12 @@ class GRPOConfig(TrainingArguments):
             "context size, which might be much larger than the KV cache, leading to inefficiencies."
         },
     )
+    vllm_max_num_seqs: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "If not set, will default to per_device_train_batch_size * TP."
+        },
+    )
 
     # Parameters that control the training
     learning_rate: float = field(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -671,16 +671,12 @@ class GRPOTrainer(Trainer):
         return selective_log_softmax(logits, input_ids)  #  compute logprobs for the input tokens
 
     def _move_model_to_vllm(self):
-        return # disable for awhile
 
         # FSPD with model sharding
         # - we move wrapped module at a time
         # NOTE: fsdp_plugin is not gauranteed to be active, so 
         # need to check for that
-        if (
-            self.accelerator.is_fsdp_enabled and
-            self.use_vllm
-        ):
+        if self.is_fsdp_enabled and self.use_vllm:
             from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP, FSDP_WRAPPED_MODULE
             from torch.distributed.fsdp._common_utils import _get_handle_fqns_from_root
 
@@ -709,16 +705,15 @@ class GRPOTrainer(Trainer):
                     with_grads=False,
                 ):
 
-                    fqns_info = []
-                    try:
-                        fqns_info = _get_handle_fqns_from_root(state, state._handle)
-                    except IndexError:
-                        pass # could be empty if wrapper has no managed aprams
+                    flat_param = state._flat_param
 
                     state_dict = {} # for this FSDP module only
                     for key, param_info in zip(
-                        fqns_info, state._flat_param._param_infos
+                        state._exec_order_data.param_to_fqn[flat_param],
+                        flat_param._param_infos
                     ):
+                        # if self.accelerator.is_main_process:
+                        #     print ('loaded', key)
                         state_dict[key] = getattr(param_info.module, param_info.param_name)
 
                     # load the partial state dict
@@ -726,9 +721,6 @@ class GRPOTrainer(Trainer):
                     del state_dict
 
             return 
-
-        # Temporary disable other paths
-        return
 
         with (
             unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -105,26 +105,6 @@ class RepeatRandomSampler(Sampler):
     def __len__(self):
         return self.num_samples * self.repeat_count
 
-def build_init_world_group(global_ranks, local_rank, f):
-    # hijack
-    # - global_ranks should only contain [[...]]
-    def _wrapper(_, __, *args, **kwargs):
-        nonlocal global_ranks
-        # we dont really support DP and PP
-        grp_name = kwargs.get("group_name")
-        # if grp_name in {'dp', 'pp'}:
-        if grp_name in {'pp'}:
-            global_ranks = [[x] for x in global_ranks[0]]
-        
-        print (local_rank, global_ranks)
-        return f(global_ranks, local_rank, *args, **kwargs)
-    return _wrapper
-
-from vllm.distributed.parallel_state import (
-    init_world_group as _init_world_group,
-    init_model_parallel_group as _init_model_parallel_group
-)
-
 # To be used if VLLM is generating 
 from typing import List
 class VLLMDeviceManager:
@@ -206,7 +186,7 @@ class VLLMDeviceManager:
         return self.process_index % self.tensor_parallel
 
     def group_devices(self):
-        i = self.local_process_index  //  self.tensor_parallel
+        i = self.process_index  //  self.tensor_parallel
         return list(range(i*self.tensor_parallel, (i+1)*self.tensor_parallel))
 
     def _group_barrier(self):
@@ -541,58 +521,37 @@ class GRPOTrainer(Trainer):
                 vllm_device=self.args.vllm_device
             )
 
-            world_size_patch = patch(
-                "torch.distributed.get_world_size", 
-                return_value=self.vllm_device_manager.tensor_parallel,
-            )
-            group_patch1 = patch(
-                "vllm.distributed.parallel_state.init_world_group",
-                build_init_world_group(
-                    self.vllm_device_manager.group_devices(),
-                    self.vllm_device_manager.local_process_index,
-                    _init_world_group
-                )
-            )
-            group_patch2 = patch(
-                "vllm.distributed.parallel_state.init_model_parallel_group",
-                build_init_world_group(
-                    [self.vllm_device_manager.group_devices()],
-                    self.vllm_device_manager.local_process_index,
-                    _init_model_parallel_group
-                )
-            )
-
             # cant seem to set the groups properly without this.
             # - because this is within the same process
-            with world_size_patch, group_patch1, group_patch2:
+            # with world_size_patch, group_patch1, group_patch2:
             # with world_size_patch, cuda_devices_patch:
-                self.llm = LLM(
-                    model=model.name_or_path,
-                    # device=self.vllm_device_manager.device,
-                    device='cuda',
-                    # device=f'cuda:{self.vllm_device_manager.vllm_device}',
-                    gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
-                    dtype=self.args.vllm_dtype,
-                    # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
-                    # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
-                    # This is particularly useful here because we generate completions from the same prompts.
-                    enable_prefix_caching=True,
-                    max_model_len=self.args.vllm_max_model_len,
-                    hf_overrides = {
-                        'max_position_embeddings': self.max_prompt_length + self.max_completion_length
-                    },
-                    max_num_seqs=(
-                        self.args.per_device_train_batch_size *
-                        self.vllm_device_manager.tensor_parallel, # because of the gather
-                    ),
-                    tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
-                    distributed_executor_backend="external_launcher",
-                    enforce_eager=True, # DEBUG
-                )
-                self.sampling_params = SamplingParams(
-                    temperature=args.temperature,
-                    max_tokens=self.max_completion_length,
-                )
+            self.llm = LLM(
+                model=model.name_or_path,
+                # device=self.vllm_device_manager.device,
+                device='cuda',
+                # device=f'cuda:{self.vllm_device_manager.vllm_device}',
+                gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
+                dtype=self.args.vllm_dtype,
+                # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
+                # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
+                # This is particularly useful here because we generate completions from the same prompts.
+                enable_prefix_caching=True,
+                max_model_len=self.args.vllm_max_model_len,
+                hf_overrides = {
+                    'max_position_embeddings': self.max_prompt_length + self.max_completion_length
+                },
+                max_num_seqs=(
+                    self.args.per_device_train_batch_size *
+                    self.vllm_device_manager.tensor_parallel # because of the gather
+                ),
+                tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
+                distributed_executor_backend="external_launcher",
+                enforce_eager=True, # DEBUG
+            )
+            self.sampling_params = SamplingParams(
+                temperature=args.temperature,
+                max_tokens=self.max_completion_length,
+            )
 
             self._last_loaded_step = 0  # tag to avoid useless loading during grad accumulation
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -592,6 +592,7 @@ class GRPOTrainer(Trainer):
                     ) if self.args.vllm_max_num_seqs is None else
                     self.args.vllm_max_num_seqs
                 ),
+                num_gpu_blocks_override=self.args.vllm_num_gpu_blocks_override,
                 tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
                 distributed_executor_backend="external_launcher",
                 # enforce_eager=True, # DEBUG

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -586,8 +586,11 @@ class GRPOTrainer(Trainer):
                     'max_position_embeddings': self.max_prompt_length + self.max_completion_length
                 },
                 max_num_seqs=(
-                    self.args.per_device_train_batch_size *
-                    self.vllm_device_manager.tensor_parallel # because of the gather
+                    (
+                        self.args.per_device_train_batch_size *
+                        self.vllm_device_manager.tensor_parallel # because of the gather
+                    ) if self.args.vllm_max_num_seqs is None else
+                    self.args.vllm_max_num_seqs
                 ),
                 tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
                 distributed_executor_backend="external_launcher",

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -782,7 +782,7 @@ class GRPOTrainer(Trainer):
                 }
             else:
                 state_dict = unwrapped_model.state_dict()
-            if self.accelerator.is_main_process:
+            if self.vllm_device_manager.is_vllm_process:                                              
                 llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
                 llm_model.load_weights(state_dict.items())
             # Unmerge the adapter to restore the model to its original state.

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -192,11 +192,6 @@ class VLLMDeviceManager:
         return output_tensors.view(-1, *tensor.size()[1:])
 
     @property
-    def is_vllm_process(self):
-        # essentially this is the mini shard leader
-        return self.is_shard_leader
-
-    @property
     def vllm_device(self):
         # NOTE: cannot handle TP for now
         # this indexes into the mini-shard local to the node
@@ -208,10 +203,6 @@ class VLLMDeviceManager:
     def local_rank_mini_shard(self):
         # rank of this process within its mini shard
         return self.process_index % self.tensor_parallel
-
-    @property
-    def is_shard_leader(self):
-        return self.local_rank_mini_shard == 0
 
     @property
     def global_rank_shard_leader(self):
@@ -277,90 +268,6 @@ class VLLMDeviceManager:
             ))
         return outputs
 
-    def scatter_tensor_list(
-        self, 
-        batch: int,
-        dtype,
-        tensors: List[torch.tensor] = None,
-    ):
-
-        # assume all the ranks give the same batch size
-
-        if tensors is not None:
-            assert len(tensors) > 0, "cannot scatter empty tensor list"
-            assert self.is_shard_leader, "only the shard leader can scatte"
-
-            # assume the tensors are 1-D
-            sizes = torch.tensor(
-                [tensors[i].shape[-1] for i in range(len(tensors))],
-                dtype=torch.int32, device=self.device
-            )
-        else:
-
-            # need to broadcast the sizes
-            sizes = torch.empty(
-                batch * self.mini_shard_size, 
-                dtype=torch.int32, device=self.device
-            )
-
-        # get all the sizes
-        self._group_barrier()
-        torch.distributed.broadcast(
-            sizes,
-            group=self._group, 
-            src=self.global_rank_shard_leader,
-        )
-
-        # total number of tokens in one mini shard
-        scattered_sizes_list = sizes.view(-1, batch).sum(axis=-1)
-
-        # largest number of tokens in one rank of the mini shard
-        max_size = scattered_sizes_list.max().item()
-
-        # scatter tensor
-
-        scattered_tensor = torch.empty(
-            # scattered_sizes.sum(),
-            max_size,
-            dtype=dtype, device=self.device
-        )
-
-        # each rank will get a cat of its batch
-        scattered_tensor_list = None
-        if self.is_shard_leader:
-            scattered_tensor_list = []
-            for i in range(self.mini_shard_size):
-
-                # collect all the tokens in the batch
-                # of a rank in the minishard
-                ids = []
-                for j in range(batch):
-                    ids.extend(tensors[i*batch+j])
-
-                # pad it to make all same rank
-                ids.extend([0] * (max_size - len(ids)))
-                scattered_tensor_list.append(
-                    torch.tensor(ids, dtype=dtype, device=self.device)
-                )
-
-        # get max_size tokens of the rank
-        self._group_barrier()
-        torch.distributed.scatter(
-            scattered_tensor, scattered_tensor_list,
-            group=self._group, 
-            src=self.global_rank_shard_leader,
-        )
-
-        # get the number of tokens in this rank
-        r = self.local_rank_mini_shard
-        szs_sum = scattered_sizes_list[r]
-        szs = sizes[r*batch:(r+1)*batch].tolist()
-
-        # drop the padding and split
-        outputs = torch.split(
-            scattered_tensor[:szs_sum], szs
-        )
-        return outputs
 
 class GRPOTrainer(Trainer):
     """
@@ -783,10 +690,11 @@ class GRPOTrainer(Trainer):
                 }
             else:
                 state_dict = unwrapped_model.state_dict()
-            if self.vllm_device_manager.is_vllm_process:                                              
-                # Should still work for TP=1
-                llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
-                llm_model.load_weights(state_dict.items())
+
+            # needs to be done for all ranks now
+            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+            llm_model.load_weights(state_dict.items())
+
             # Unmerge the adapter to restore the model to its original state.
             # This must be done after loading weights to ensure they correspond to the merged state.
             if is_peft_model(unwrapped_model):
@@ -825,8 +733,8 @@ class GRPOTrainer(Trainer):
             outputs = self.llm.generate(
                 prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
                 sampling_params=self.sampling_params, 
-                # use_tqdm=False,
-                use_tqdm=self.accelerator.is_local_main_process
+                use_tqdm=False,
+                # use_tqdm=self.accelerator.is_local_main_process
                 # use_tqdm=self.accelerator.process_index == 3
             )
             completion_ids = [

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -477,6 +477,36 @@ class GRPOTrainer(Trainer):
             optimizers=optimizers,
         )
 
+        if not is_deepspeed_zero3_enabled():
+
+            # for big models wrap it
+            def is_embedding_policy(
+                module: torch.nn.Module,
+                recurse: bool,
+                nonwrapped_numel: int,
+            ):
+                if recurse:
+                    # always recurse
+                    return True
+
+                C = module.__class__.__name__
+                return (
+                    C == 'Embedding' or (
+                        C == 'Linear' and 
+                        max(*module.weight.shape) > 100000
+                    )
+                )
+
+            self.accelerator.state.fsdp_plugin.set_auto_wrap_policy(self.model)
+            from torch.distributed.fsdp.wrap import _or_policy
+            from functools import partial
+            self.accelerator.state.fsdp_plugin.auto_wrap_policy = partial(
+                _or_policy, policies = [
+                    self.accelerator.state.fsdp_plugin.auto_wrap_policy, 
+                    is_embedding_policy
+                ]
+            )
+
         if self.ref_model is not None and not is_deepspeed_zero3_enabled():
             # NOTE: we still should FSDP the model
             self.ref_model = self.accelerator.prepare(self.ref_model)
@@ -721,7 +751,7 @@ class GRPOTrainer(Trainer):
         if self.args.use_vllm:
             # First, have main process load weights if needed
             if self.state.global_step != self._last_loaded_step:
-                self._move_model_to_vllm()
+                # self._move_model_to_vllm()
                 self._last_loaded_step = self.state.global_step
 
             # Generate completions using vLLM: gather all prompts and use them in a single call in the main process

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -653,11 +653,14 @@ class GRPOTrainer(Trainer):
         return selective_log_softmax(logits, input_ids)  #  compute logprobs for the input tokens
 
     def _move_model_to_vllm(self):
+        return # disable for awhile
 
         # FSPD with model sharding
         # - we move wrapped module at a time
+        # NOTE: fsdp_plugin is not gauranteed to be active, so 
+        # need to check for that
         if (
-            self.accelerator.state.fsdp_plugin is not None and
+            self.accelerator.is_fsdp_enabled and
             self.use_vllm
         ):
             from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP, FSDP_WRAPPED_MODULE
@@ -688,10 +691,15 @@ class GRPOTrainer(Trainer):
                     with_grads=False,
                 ):
 
+                    fqns_info = []
+                    try:
+                        fqns_info = _get_handle_fqns_from_root(state, state._handle)
+                    except IndexError:
+                        pass # could be empty if wrapper has no managed aprams
+
                     state_dict = {} # for this FSDP module only
                     for key, param_info in zip(
-                        _get_handle_fqns_from_root(state, state._handle), 
-                        state._flat_param._param_infos
+                        fqns_info, state._flat_param._param_infos
                     ):
                         state_dict[key] = getattr(param_info.module, param_info.param_name)
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -284,6 +284,30 @@ def fsdp_sharding_policy(auto_wrap_policy, embedding_vocab_size: int = 100000):
         ]
     )
 
+def create_torch_profiler(directory_name: str = 'profiler_traces'):
+
+    profiler = torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ],
+        schedule=torch.profiler.schedule(wait=1, warmup=2, active=3, repeat=1),
+        on_trace_ready=torch.profiler.tensorboard_trace_handler(directory_name),
+        profile_memory=True,
+        with_stack=False,
+        record_shapes=True,
+    )
+
+    class ProfCallback(TrainerCallback):
+        def __init__(self):
+            self.profiler = profiler
+
+        def on_step_end(self, args, state, control, **kwargs):
+            print('profiler step step step')
+            self.profiler.step()
+
+    return ProfCallback()
+
 class GRPOTrainer(Trainer):
     """
     Trainer for the Group Relative Policy Optimization (GRPO) method. This algorithm was initially proposed in the
@@ -640,6 +664,17 @@ class GRPOTrainer(Trainer):
             if isinstance(reward_func, PreTrainedModel):
                 self.reward_funcs[i] = self.accelerator.prepare_model(reward_func, evaluation_mode=True)
 
+        # torch profiler
+        if (
+            os.environ.get('ENABLE_PROFILER', 'false') == 'true'
+            and self.accelerator.is_main_process
+        ):
+            print ('profiler created!!!')
+            profiler_callback = create_torch_profiler(
+                os.path.join(self.args.output_dir, 'profiler_traces')
+            )
+            self.add_callback(profiler_callback)
+
     def _set_signature_columns_if_needed(self):
         # If `self.args.remove_unused_columns` is True, non-signature columns are removed.
         # By default, this method sets `self._signature_columns` to the model's expected inputs.
@@ -791,8 +826,8 @@ class GRPOTrainer(Trainer):
             outputs = self.llm.generate(
                 prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
                 sampling_params=self.sampling_params, 
-                # use_tqdm=False,
-                use_tqdm=self.accelerator.is_local_main_process
+                use_tqdm=False,
+                # use_tqdm=self.accelerator.is_local_main_process
                 # use_tqdm=self.accelerator.process_index == 3
             )
             completion_ids = [

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -105,10 +105,10 @@ class RepeatRandomSampler(Sampler):
     def __len__(self):
         return self.num_samples * self.repeat_count
 
-def build_init_world_group(ranks, f):
+def build_init_world_group(global_ranks, local_rank, f):
     # hijack
-    def _wrapper(_, *args, **kwargs):
-        return f(ranks, *args, **kwargs)
+    def _wrapper(_, __, *args, **kwargs):
+        return f(global_ranks, local_rank, *args, **kwargs)
     return _wrapper
 
 from vllm.distributed.parallel_state import (
@@ -135,18 +135,15 @@ class VLLMDeviceManager:
         self.local_process_index = local_process_index
         self.device = f'cuda:{local_process_index}'
 
+        if vllm_device.startswith("tp:"):
+            self.tensor_parallel = vllm_device.split(":")
+            self.tensor_parallel = int(self.tensor_parallel)
+
         # get the local world size
         # https://pytorch.org/docs/stable/elastic/run.html#environment-variables
         self.local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
-        assert self.local_world_size % self.mini_shards == 0, "number of mini shards must divide local world size"
+        assert self.local_world_size % self.tensor_parallel == 0, "tp_degree must divide local world size"
 
-        # NOTE: some draft code
-        if vllm_device.startswith("auto:"):
-            _,  self.mini_shards, self.tensor_parallel = vllm_device.split(":")
-            self.mini_shards = int(self.mini_shards)
-            self.tensor_parallel = int(self.tensor_parallel)
-
-        self.mini_shard_size = self.local_world_size // self.mini_shards
 
         # NOTE: disable these checks first. until finalize how to handle the distributed devices
         # vllm_device = self.args.vllm_device
@@ -177,8 +174,8 @@ class VLLMDeviceManager:
         world_size = torch.distributed.get_world_size()
         self._group, subgroups  = torch.distributed.new_subgroups_by_enumeration(
             [
-                list(range(i*self.mini_shard_size, (i+1) * self.mini_shard_size)) 
-                for i in range(world_size // self.mini_shard_size)
+                list(range(i*self.tensor_parallel, (i+1) * self.tensor_parallel)) 
+                for i in range(world_size // self.tensor_parallel)
             ]
         )
 
@@ -210,7 +207,7 @@ class VLLMDeviceManager:
     @property
     def local_rank_mini_shard(self):
         # rank of this process within its mini shard
-        return self.process_index % self.mini_shard_size
+        return self.process_index % self.tensor_parallel
 
     @property
     def is_shard_leader(self):
@@ -222,12 +219,20 @@ class VLLMDeviceManager:
         mini_shard_idx = self.process_index // self.mini_shard_size
         return mini_shard_idx * self.mini_shard_size
 
+    def group_devices(self):
+        i = self.local_process_index  //  self.tensor_parallel
+        return list(range(i*self.tensor_parallel, (i+1)*self.tensor_parallel))
+
     def _group_barrier(self):
         torch.distributed.barrier(
             group=self._group, device_ids=[self.local_process_index]
         )
 
     def gather_tensor_list(self, tensors: List[torch.tensor]):
+
+        if self.tensor_parallel == 1:
+            # pass through
+            return tensors
 
         batch = len(tensors)
         assert batch > 0, "cannot gather empty tensor list"
@@ -252,7 +257,7 @@ class VLLMDeviceManager:
                 gathered_sizes[i*batch:(i+1)*batch].sum(),
                 dtype=dtype, device=self.device
             )
-            for i in range(self.mini_shard_size)
+            for i in range(self.tensor_parallel)
         ]
 
         # have to use gather because we cannot gaurantee
@@ -264,12 +269,8 @@ class VLLMDeviceManager:
             group=self._group, 
         )
 
-        # pretend like its a gather
-        if not self.is_shard_leader:
-            return None
-
         outputs = []
-        for i in range(self.mini_shard_size):
+        for i in range(self.tensor_parallel):
             batch_sizes = gathered_sizes[i*batch:(i+1)*batch].tolist()
             outputs.extend(torch.split(
                 output_objects[i], batch_sizes,
@@ -638,50 +639,50 @@ class GRPOTrainer(Trainer):
                 vllm_device=self.args.vllm_device
             )
 
+            world_size_patch = patch(
+                "torch.distributed.get_world_size", 
+                return_value=self.vllm_device_manager.tensor_parallel,
+            )
+            group_patch1 = patch(
+                "vllm.distributed.parallel_state.init_world_group",
+                build_init_world_group(
+                    self.vllm_device_manager.group_devices(),
+                    self.vllm_device_manager.local_process_index,
+                    _init_world_group
+                )
+            )
+            group_patch2 = patch(
+                "vllm.distributed.parallel_state.init_model_parallel_group",
+                build_init_world_group(
+                    [self.vllm_device_manager.group_devices()],
+                    self.vllm_device_manager.local_process_index,
+                    _init_model_parallel_group
+                )
+            )
 
-            if self.vllm_device_manager.is_vllm_process:
-
-                # vLLM is not compatible with accelerate. So we need to patch it to make sure we can (1) place the vLLM
-                # model on the desired device (world_size_patch) and (2) avoid a test that is not designed for our
-                # setting (profiling_patch).
-                world_size_patch = patch(
-                    "torch.distributed.get_world_size", 
-                    return_value=self.vllm_device_manager.tensor_parallel,
+            # cant seem to set the groups properly without this.
+            # - because this is within the same process
+            with world_size_patch, group_patch1, group_patch2:
+            # with world_size_patch, cuda_devices_patch:
+                self.llm = LLM(
+                    model=model.name_or_path,
+                    # device=self.vllm_device_manager.device,
+                    device='cuda',
+                    # device=f'cuda:{self.vllm_device_manager.vllm_device}',
+                    gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
+                    dtype=self.args.vllm_dtype,
+                    # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
+                    # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
+                    # This is particularly useful here because we generate completions from the same prompts.
+                    enable_prefix_caching=True,
+                    max_model_len=self.args.vllm_max_model_len,
+                    hf_overrides = {
+                        'max_position_embeddings': self.max_prompt_length + self.max_completion_length
+                    },
+                    tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
+                    distributed_executor_backend="external_launcher",
+                    enforce_eager=True, # DEBUG
                 )
-                profiling_patch = patch(
-                    "vllm.worker.worker.Worker._assert_memory_footprint_increased_during_profiling", return_value=None
-                )
-                # these are used to pass through the dist groups
-                # - dont really understand how VLLM manages the processs
-                #   groups
-                group_patch1 = patch(
-                    "vllm.distributed.parallel_state.init_world_group",
-                    build_init_world_group([
-                        torch.distributed.get_rank()
-                    ], _init_world_group)
-                )
-                group_patch2 = patch(
-                    "vllm.distributed.parallel_state.init_model_parallel_group",
-                    build_init_world_group([[
-                        torch.distributed.get_rank()
-                    ]], _init_model_parallel_group)
-                )
-                with world_size_patch, group_patch1, group_patch2, profiling_patch:
-                    self.llm = LLM(
-                        model=model.name_or_path,
-                        device=f'cuda:{self.vllm_device_manager.vllm_device}',
-                        gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
-                        dtype=self.args.vllm_dtype,
-                        # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
-                        # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
-                        # This is particularly useful here because we generate completions from the same prompts.
-                        enable_prefix_caching=True,
-                        max_model_len=self.args.vllm_max_model_len,
-                        hf_overrides = {
-                            'max_position_embeddings': self.max_prompt_length + self.max_completion_length
-                        },
-                        # enforce_eager=True, # DEBUG
-                    )
                 self.sampling_params = SamplingParams(
                     temperature=args.temperature,
                     max_tokens=self.max_completion_length,
@@ -783,6 +784,7 @@ class GRPOTrainer(Trainer):
             else:
                 state_dict = unwrapped_model.state_dict()
             if self.vllm_device_manager.is_vllm_process:                                              
+                # Should still work for TP=1
                 llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
                 llm_model.load_weights(state_dict.items())
             # Unmerge the adapter to restore the model to its original state.
@@ -817,27 +819,34 @@ class GRPOTrainer(Trainer):
                 torch.tensor(x, dtype=torch.int32, device=device)
                 for x in self.processing_class(prompts_text)['input_ids']
             ]
+
+            # need to gather the tokens from the TP copies
             all_prompts_ids = self.vllm_device_manager.gather_tensor_list(prompts_tokens)
-            if self.vllm_device_manager.is_vllm_process:                                              
-                outputs = self.llm.generate(
-                    prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
-                    sampling_params=self.sampling_params, 
-                    use_tqdm=False,
-                    # use_tqdm=self.accelerator.is_local_main_process
-                    # use_tqdm=self.accelerator.process_index == 3
-                )
-                completion_ids = [
-                    torch.tensor(out.token_ids, dtype=torch.int32, device=device)
-                    for completions in outputs for out in completions.outputs
-                ]
-            else:
-                completion_ids = None
+            outputs = self.llm.generate(
+                prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
+                sampling_params=self.sampling_params, 
+                # use_tqdm=False,
+                use_tqdm=self.accelerator.is_local_main_process
+                # use_tqdm=self.accelerator.process_index == 3
+            )
+            completion_ids = [
+                torch.tensor(out.token_ids, dtype=torch.int32, device=device)
+                for completions in outputs for out in completions.outputs
+            ]
 
             # Broadcast the completions from the main process to all processes, ensuring each process receives its
             # corresponding slice.
-            completion_ids = self.vllm_device_manager.scatter_tensor_list(
-                tensors=completion_ids, dtype=torch.int32, batch=len(prompts),
-            )
+            # completion_ids = self.vllm_device_manager.scatter_tensor_list(
+            #     tensors=completion_ids, dtype=torch.int32, batch=len(prompts),
+            # )
+            # Slice to keep only the local part of the data
+            if self.vllm_device_manager.tensor_parallel > 1:
+                process_index = self.vllm_device_manager.local_rank_mini_shard
+                tp_slice = slice(
+                    process_index * len(prompts),
+                    (process_index + 1) * len(prompts),
+                )
+                completion_ids = completion_ids[tp_slice]
 
             # Pad the completions, and concatenate them with the prompts
             completion_ids = pad(completion_ids, padding_value=self.processing_class.pad_token_id)

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -243,6 +243,46 @@ class VLLMDeviceManager:
             ))
         return outputs
 
+def is_fsdp_sharding_enabled():
+
+    # use the plugin to help us parse the mode
+    from accelerate import FullyShardedDataParallelPlugin
+    from torch.distributed.fsdp import ShardingStrategy
+    plugin = FullyShardedDataParallelPlugin()
+    return plugin.sharding_strategy in {
+        ShardingStrategy.FULL_SHARD, 
+        ShardingStrategy.HYBRID_SHARD
+    }
+
+def fsdp_sharding_policy(auto_wrap_policy, embedding_vocab_size: int = 100000):
+
+    # for big models wrap it
+    def is_module_embedding(
+        module: torch.nn.Module,
+        recurse: bool,
+        nonwrapped_numel: int,
+    ):
+        if recurse:
+            # always recurse
+            return True
+
+        return (
+            isinstance(module, torch.nn.Embedding) or
+            (
+                isinstance(module, torch.nn.Linear) and
+                max(*module.weight.shape) > embedding_vocab_size
+            )
+        )
+
+    # a slighly improved one over the transformers wrapping policy
+    # that also wraps the embedding and head
+    from torch.distributed.fsdp.wrap import _or_policy
+    from functools import partial
+    return partial(
+        _or_policy, policies = [
+            auto_wrap_policy, is_module_embedding
+        ]
+    )
 
 class GRPOTrainer(Trainer):
     """
@@ -386,16 +426,16 @@ class GRPOTrainer(Trainer):
             model = get_peft_model(model, peft_config)
 
         # Reference model
-        # if is_deepspeed_zero3_enabled():
-        #     self.ref_model = AutoModelForCausalLM.from_pretrained(model_id, **model_init_kwargs)
-        # elif not is_peft_model(model):
-        #     # If PEFT configuration is not provided, create a reference model based on the initial model.
-        #     self.ref_model = create_reference_model(model)
-        # else:
-        #     # If PEFT is used, the reference model is not needed since the adapter can be disabled
-        #     # to revert to the initial model.
-        #     self.ref_model = None
-        self.ref_model = None
+        if is_deepspeed_zero3_enabled() or is_fsdp_sharding_enabled():
+            self.ref_model = AutoModelForCausalLM.from_pretrained(model_id, **model_init_kwargs)
+            print ('No CLONING of Ref MODEL!')
+        elif not is_peft_model(model):
+            # If PEFT configuration is not provided, create a reference model based on the initial model.
+            self.ref_model = create_reference_model(model)
+        else:
+            # If PEFT is used, the reference model is not needed since the adapter can be disabled
+            # to revert to the initial model.
+            self.ref_model = None
 
         # Processing class
         if processing_class is None:
@@ -478,34 +518,12 @@ class GRPOTrainer(Trainer):
             optimizers=optimizers,
         )
 
-        if not is_deepspeed_zero3_enabled():
+        if is_fsdp_sharding_enabled():
 
-            # for big models wrap it
-            def is_embedding_policy(
-                module: torch.nn.Module,
-                recurse: bool,
-                nonwrapped_numel: int,
-            ):
-                if recurse:
-                    # always recurse
-                    return True
-
-                C = module.__class__.__name__
-                return (
-                    C == 'Embedding' or (
-                        C == 'Linear' and 
-                        max(*module.weight.shape) > 100000
-                    )
-                )
-
+            # do this to initialze the transformers policy
             self.accelerator.state.fsdp_plugin.set_auto_wrap_policy(self.model)
-            from torch.distributed.fsdp.wrap import _or_policy
-            from functools import partial
-            self.accelerator.state.fsdp_plugin.auto_wrap_policy = partial(
-                _or_policy, policies = [
-                    self.accelerator.state.fsdp_plugin.auto_wrap_policy, 
-                    is_embedding_policy
-                ]
+            self.accelerator.state.fsdp_plugin.auto_wrap_policy = (
+                fsdp_sharding_policy(self.accelerator.state.fsdp_plugin.auto_wrap_policy)
             )
 
         # Check if the per_device_train/eval_batch_size * num processes can be divided by the number of generations
@@ -605,11 +623,11 @@ class GRPOTrainer(Trainer):
         if self.ref_model is not None:
             if self.is_deepspeed_enabled:
                 self.ref_model = prepare_deepspeed(self.ref_model, self.accelerator)
+            elif self.is_fsdp_enabled:
+                self.ref_model = self.accelerator.prepare(self.ref_model)
             else:
                 # this one has no sharding
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
-                # self.ref_model = self.accelerator.prepare(self.ref_model)
-
 
         if args.sync_ref_model:
             self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
@@ -827,16 +845,16 @@ class GRPOTrainer(Trainer):
 
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
 
-        # with torch.inference_mode():
-        #     if self.ref_model is not None:
-        #         ref_per_token_logps = self._get_per_token_logps(
-        #             self.ref_model, prompt_completion_ids, attention_mask, logits_to_keep
-        #         )
-        #     else:
-        #         with self.accelerator.unwrap_model(self.model).disable_adapter():
-        #             ref_per_token_logps = self._get_per_token_logps(
-        #                 self.model, prompt_completion_ids, attention_mask, logits_to_keep
-        #             )
+        with torch.inference_mode():
+            if self.ref_model is not None:
+                ref_per_token_logps = self._get_per_token_logps(
+                    self.ref_model, prompt_completion_ids, attention_mask, logits_to_keep
+                )
+            else:
+                with self.accelerator.unwrap_model(self.model).disable_adapter():
+                    ref_per_token_logps = self._get_per_token_logps(
+                        self.model, prompt_completion_ids, attention_mask, logits_to_keep
+                    )
 
         # Decode the generated completions
         completions_text = self.processing_class.batch_decode(completion_ids, skip_special_tokens=True)
@@ -932,7 +950,7 @@ class GRPOTrainer(Trainer):
             "prompt_mask": prompt_mask,
             "completion_ids": completion_ids,
             "completion_mask": completion_mask,
-            # "ref_per_token_logps": ref_per_token_logps,
+            "ref_per_token_logps": ref_per_token_logps,
             "advantages": advantages,
         }
 
@@ -950,9 +968,8 @@ class GRPOTrainer(Trainer):
         per_token_logps = self._get_per_token_logps(model, input_ids, attention_mask, logits_to_keep)
 
         # Compute the KL divergence between the model and the reference model
-        # ref_per_token_logps = inputs["ref_per_token_logps"]
-        # per_token_kl = torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
-        per_token_kl = 0
+        ref_per_token_logps = inputs["ref_per_token_logps"]
+        per_token_kl = torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
 
         # x - x.detach() allows for preserving gradients from x
         advantages = inputs["advantages"]
@@ -971,8 +988,8 @@ class GRPOTrainer(Trainer):
         completion_length = self.accelerator.gather_for_metrics(completion_mask.sum(1)).float().mean().item()
         self._metrics["completion_length"].append(completion_length)
 
-        # mean_kl = (per_token_kl * completion_mask).sum() / completion_mask.sum()
-        # self._metrics["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
+        mean_kl = (per_token_kl * completion_mask).sum() / completion_mask.sum()
+        self._metrics["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
 
         return loss
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -107,7 +107,12 @@ class RepeatRandomSampler(Sampler):
 
 def build_init_world_group(global_ranks, local_rank, f):
     # hijack
+    # - global_ranks should only contain [[...]]
     def _wrapper(_, __, *args, **kwargs):
+        # we dont really support DP and PP
+        grp_name = kwargs.get("group_name")
+        if grp_name in {'dp', 'pp'}:
+            return f([[x] for x in global_ranks[0]], local_rank, *args, **kwargs)
         return f(global_ranks, local_rank, *args, **kwargs)
     return _wrapper
 
@@ -136,7 +141,7 @@ class VLLMDeviceManager:
         self.device = f'cuda:{local_process_index}'
 
         if vllm_device.startswith("tp:"):
-            self.tensor_parallel = vllm_device.split(":")
+            self.tensor_parallel = vllm_device.split(":")[-1]
             self.tensor_parallel = int(self.tensor_parallel)
 
         # get the local world size
@@ -183,7 +188,7 @@ class VLLMDeviceManager:
         # this follows accelerate.utils.operations.gather, which is an all 
         # gather operation, used to implement the gather op here.
         output_tensors = torch.empty(
-            self.mini_shard_size * tensor.numel(),
+            self.tensor_parallel * tensor.numel(),
             dtype=tensor.dtype,
             device=tensor.device,
         )
@@ -191,24 +196,24 @@ class VLLMDeviceManager:
         torch.distributed.all_gather_into_tensor(output_tensors, tensor, group=self._group)
         return output_tensors.view(-1, *tensor.size()[1:])
 
-    @property
-    def vllm_device(self):
-        # NOTE: cannot handle TP for now
-        # this indexes into the mini-shard local to the node
-        local_mini_shard_index = self.local_process_index // self.mini_shard_size
-        # FIXME: this one is to be changed when we consider TP and local shards
-        return self.local_world_size + local_mini_shard_index
+    # @property
+    # def vllm_device(self):
+    #     # NOTE: cannot handle TP for now
+    #     # this indexes into the mini-shard local to the node
+    #     local_mini_shard_index = self.local_process_index // self.mini_shard_size
+    #     # FIXME: this one is to be changed when we consider TP and local shards
+    #     return self.local_world_size + local_mini_shard_index
 
     @property
     def local_rank_mini_shard(self):
         # rank of this process within its mini shard
         return self.process_index % self.tensor_parallel
 
-    @property
-    def global_rank_shard_leader(self):
-        # the global rank of the shard leader
-        mini_shard_idx = self.process_index // self.mini_shard_size
-        return mini_shard_idx * self.mini_shard_size
+    # @property
+    # def global_rank_shard_leader(self):
+    #     # the global rank of the shard leader
+    #     mini_shard_idx = self.process_index // self.mini_shard_size
+    #     return mini_shard_idx * self.mini_shard_size
 
     def group_devices(self):
         i = self.local_process_index  //  self.tensor_parallel

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -386,15 +386,16 @@ class GRPOTrainer(Trainer):
             model = get_peft_model(model, peft_config)
 
         # Reference model
-        if is_deepspeed_zero3_enabled():
-            self.ref_model = AutoModelForCausalLM.from_pretrained(model_id, **model_init_kwargs)
-        elif not is_peft_model(model):
-            # If PEFT configuration is not provided, create a reference model based on the initial model.
-            self.ref_model = create_reference_model(model)
-        else:
-            # If PEFT is used, the reference model is not needed since the adapter can be disabled
-            # to revert to the initial model.
-            self.ref_model = None
+        # if is_deepspeed_zero3_enabled():
+        #     self.ref_model = AutoModelForCausalLM.from_pretrained(model_id, **model_init_kwargs)
+        # elif not is_peft_model(model):
+        #     # If PEFT configuration is not provided, create a reference model based on the initial model.
+        #     self.ref_model = create_reference_model(model)
+        # else:
+        #     # If PEFT is used, the reference model is not needed since the adapter can be disabled
+        #     # to revert to the initial model.
+        #     self.ref_model = None
+        self.ref_model = None
 
         # Processing class
         if processing_class is None:
@@ -507,10 +508,6 @@ class GRPOTrainer(Trainer):
                 ]
             )
 
-        if self.ref_model is not None and not is_deepspeed_zero3_enabled():
-            # NOTE: we still should FSDP the model
-            self.ref_model = self.accelerator.prepare(self.ref_model)
-
         # Check if the per_device_train/eval_batch_size * num processes can be divided by the number of generations
         num_processes = self.accelerator.num_processes
         global_batch_size = args.per_device_train_batch_size * num_processes
@@ -609,7 +606,10 @@ class GRPOTrainer(Trainer):
             if self.is_deepspeed_enabled:
                 self.ref_model = prepare_deepspeed(self.ref_model, self.accelerator)
             else:
+                # this one has no sharding
                 self.ref_model = self.accelerator.prepare_model(self.ref_model, evaluation_mode=True)
+                # self.ref_model = self.accelerator.prepare(self.ref_model)
+
 
         if args.sync_ref_model:
             self.add_callback(SyncRefModelCallback(ref_model=self.ref_model, accelerator=self.accelerator))
@@ -819,16 +819,16 @@ class GRPOTrainer(Trainer):
 
         logits_to_keep = completion_ids.size(1)  # we only need to compute the logits for the completion tokens
 
-        with torch.inference_mode():
-            if self.ref_model is not None:
-                ref_per_token_logps = self._get_per_token_logps(
-                    self.ref_model, prompt_completion_ids, attention_mask, logits_to_keep
-                )
-            else:
-                with self.accelerator.unwrap_model(self.model).disable_adapter():
-                    ref_per_token_logps = self._get_per_token_logps(
-                        self.model, prompt_completion_ids, attention_mask, logits_to_keep
-                    )
+        # with torch.inference_mode():
+        #     if self.ref_model is not None:
+        #         ref_per_token_logps = self._get_per_token_logps(
+        #             self.ref_model, prompt_completion_ids, attention_mask, logits_to_keep
+        #         )
+        #     else:
+        #         with self.accelerator.unwrap_model(self.model).disable_adapter():
+        #             ref_per_token_logps = self._get_per_token_logps(
+        #                 self.model, prompt_completion_ids, attention_mask, logits_to_keep
+        #             )
 
         # Decode the generated completions
         completions_text = self.processing_class.batch_decode(completion_ids, skip_special_tokens=True)
@@ -924,7 +924,7 @@ class GRPOTrainer(Trainer):
             "prompt_mask": prompt_mask,
             "completion_ids": completion_ids,
             "completion_mask": completion_mask,
-            "ref_per_token_logps": ref_per_token_logps,
+            # "ref_per_token_logps": ref_per_token_logps,
             "advantages": advantages,
         }
 
@@ -942,8 +942,9 @@ class GRPOTrainer(Trainer):
         per_token_logps = self._get_per_token_logps(model, input_ids, attention_mask, logits_to_keep)
 
         # Compute the KL divergence between the model and the reference model
-        ref_per_token_logps = inputs["ref_per_token_logps"]
-        per_token_kl = torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
+        # ref_per_token_logps = inputs["ref_per_token_logps"]
+        # per_token_kl = torch.exp(ref_per_token_logps - per_token_logps) - (ref_per_token_logps - per_token_logps) - 1
+        per_token_kl = 0
 
         # x - x.detach() allows for preserving gradients from x
         advantages = inputs["advantages"]
@@ -962,8 +963,8 @@ class GRPOTrainer(Trainer):
         completion_length = self.accelerator.gather_for_metrics(completion_mask.sum(1)).float().mean().item()
         self._metrics["completion_length"].append(completion_length)
 
-        mean_kl = (per_token_kl * completion_mask).sum() / completion_mask.sum()
-        self._metrics["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
+        # mean_kl = (per_token_kl * completion_mask).sum() / completion_mask.sum()
+        # self._metrics["kl"].append(self.accelerator.gather_for_metrics(mean_kl).mean().item())
 
         return loss
 

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -133,7 +133,7 @@ class VLLMDeviceManager:
         self.tensor_parallel = 1
         self.process_index = process_index
         self.local_process_index = local_process_index
-        self.device = f'cuda:{process_index}'
+        self.device = f'cuda:{local_process_index}'
 
         # get the local world size
         # https://pytorch.org/docs/stable/elastic/run.html#environment-variables
@@ -224,7 +224,7 @@ class VLLMDeviceManager:
 
     def _group_barrier(self):
         torch.distributed.barrier(
-            group=self._group, device_ids=[self.process_index]
+            group=self._group, device_ids=[self.local_process_index]
         )
 
     def gather_tensor_list(self, tensors: List[torch.tensor]):
@@ -826,7 +826,8 @@ class GRPOTrainer(Trainer):
                 outputs = self.llm.generate(
                     prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
                     sampling_params=self.sampling_params, 
-                    use_tqdm=self.accelerator.is_local_main_process
+                    use_tqdm=False,
+                    # use_tqdm=self.accelerator.is_local_main_process
                     # use_tqdm=self.accelerator.process_index == 3
                 )
                 completion_ids = [

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -701,6 +701,9 @@ class GRPOTrainer(Trainer):
 
             return 
 
+        # Temporary disable other paths
+        return
+
         with (
             unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model
         ):
@@ -751,7 +754,7 @@ class GRPOTrainer(Trainer):
         if self.args.use_vllm:
             # First, have main process load weights if needed
             if self.state.global_step != self._last_loaded_step:
-                # self._move_model_to_vllm()
+                self._move_model_to_vllm()
                 self._last_loaded_step = self.state.global_step
 
             # Generate completions using vLLM: gather all prompts and use them in a single call in the main process

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -721,6 +721,7 @@ class GRPOTrainer(Trainer):
         if self.args.use_vllm:
             # First, have main process load weights if needed
             if self.state.global_step != self._last_loaded_step:
+                self._move_model_to_vllm()
                 self._last_loaded_step = self.state.global_step
 
             # Generate completions using vLLM: gather all prompts and use them in a single call in the main process

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -601,10 +601,7 @@ class GRPOTrainer(Trainer):
                 # device=f'cuda:{self.vllm_device_manager.vllm_device}',
                 gpu_memory_utilization=self.args.vllm_gpu_memory_utilization,
                 dtype=self.args.vllm_dtype,
-                # Automatic Prefix Caching caches the KV cache of existing queries, so that a new query can
-                # directly reuse the KV cache if it shares the same prefix with one of the existing queries.
-                # This is particularly useful here because we generate completions from the same prompts.
-                enable_prefix_caching=True,
+                enable_prefix_caching=False,
                 max_model_len=self.args.vllm_max_model_len,
                 hf_overrides = {
                     'max_position_embeddings': self.max_prompt_length + self.max_completion_length

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -586,6 +586,7 @@ class GRPOTrainer(Trainer):
                     hf_overrides = {
                         'max_position_embeddings': self.max_prompt_length + self.max_completion_length
                     },
+                    max_num_seqs=self.args.per_device_train_batch_size,
                     tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
                     distributed_executor_backend="external_launcher",
                     enforce_eager=True, # DEBUG
@@ -665,10 +666,55 @@ class GRPOTrainer(Trainer):
         return selective_log_softmax(logits, input_ids)  #  compute logprobs for the input tokens
 
     def _move_model_to_vllm(self):
-        # this patch is for accelerate.utils.other.extract_model_from_parallel
-        # because otherwise it will mess with the top-level FSDP wrapper
+
+        # FSPD with model sharding
+        # - we move wrapped module at a time
+        if (
+            self.accelerator.state.fsdp_plugin is not None and
+            self.use_vllm
+        ):
+            from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP, FSDP_WRAPPED_MODULE
+            from torch.distributed.fsdp._common_utils import _get_handle_fqns_from_root
+
+            # pointed to the llm model
+            llm_model = self.llm.llm_engine.model_executor.driver_worker.model_runner.model
+
+            # FSDP does not have a nice function to unshard module by module
+            # - so we need to use a lot of internals
+            # - maybe cleaner way is to install a forward hook and do one dummy 
+            #   forward
+            from torch.distributed.fsdp._unshard_param_utils import _unshard_params_for_summon
+            if not hasattr(self, '_fsdp_modules'):
+
+                # memorize the traversal because it will be very slow
+                import torch.distributed.fsdp._traversal_utils as traversal_utils
+                self._fsdp_modules = traversal_utils._get_fsdp_states_with_modules(self.model)
+
+            # needs to be done for all ranks now
+            for state, module in zip(*self._fsdp_modules):
+                with _unshard_params_for_summon(
+                    module=module,
+                    state=state,
+                    writeback=False,
+                    rank0_only=False,
+                    offload_to_cpu=False,
+                    with_grads=False,
+                ):
+
+                    state_dict = {} # for this FSDP module only
+                    for key, param_info in zip(
+                        _get_handle_fqns_from_root(state, state._handle), 
+                        state._flat_param._param_infos
+                    ):
+                        state_dict[key] = getattr(param_info.module, param_info.param_name)
+
+                    # load the partial state dict
+                    llm_model.load_weights(state_dict.items())
+                    del state_dict
+
+            return 
+
         with (
-            patch("accelerate.utils.other.is_torch_distributed_available", return_value=False),
             unwrap_model_for_generation(self.model, self.accelerator) as unwrapped_model
         ):
             if is_compiled_module(unwrapped_model):
@@ -718,7 +764,6 @@ class GRPOTrainer(Trainer):
         if self.args.use_vllm:
             # First, have main process load weights if needed
             if self.state.global_step != self._last_loaded_step:
-                self._move_model_to_vllm()
                 self._last_loaded_step = self.state.global_step
 
             # Generate completions using vLLM: gather all prompts and use them in a single call in the main process

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -638,10 +638,6 @@ class GRPOTrainer(Trainer):
                 vllm_device=self.args.vllm_device
             )
 
-            assert (
-                (self.vllm_device_manager.mini_shard_size * args.per_device_train_batch_size) 
-                % self.num_generations == 0
-            ), "generations must devide mini_shard_size * per device batch size "
 
             if self.vllm_device_manager.is_vllm_process:
 
@@ -916,10 +912,7 @@ class GRPOTrainer(Trainer):
 
         # Gather the reward per function: this part is crucial, because the rewards are normalized per group and the
         # completions may be distributed across processes
-        if self.args.use_vllm:
-            rewards_per_func = self.vllm_device_manager.gather(rewards_per_func)
-        else:
-            rewards_per_func = gather(rewards_per_func)
+        rewards_per_func = gather(rewards_per_func)
 
         # Apply weights to each reward function's output and sum
         rewards = (rewards_per_func * self.reward_weights.to(device).unsqueeze(0)).sum(dim=1)
@@ -933,10 +926,7 @@ class GRPOTrainer(Trainer):
         std_grouped_rewards = std_grouped_rewards.repeat_interleave(self.num_generations, dim=0)
         advantages = (rewards - mean_grouped_rewards) / (std_grouped_rewards + 1e-4)
 
-        if self.args.use_vllm:
-            process_index = self.vllm_device_manager.local_rank_mini_shard
-        else:
-            process_index = self.accelerator.process_index
+        process_index = self.accelerator.process_index
 
         # Slice to keep only the local part of the data
         process_slice = slice(

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -546,7 +546,7 @@ class GRPOTrainer(Trainer):
                 ),
                 tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
                 distributed_executor_backend="external_launcher",
-                enforce_eager=True, # DEBUG
+                # enforce_eager=True, # DEBUG
             )
             self.sampling_params = SamplingParams(
                 temperature=args.temperature,

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -109,10 +109,14 @@ def build_init_world_group(global_ranks, local_rank, f):
     # hijack
     # - global_ranks should only contain [[...]]
     def _wrapper(_, __, *args, **kwargs):
+        nonlocal global_ranks
         # we dont really support DP and PP
         grp_name = kwargs.get("group_name")
-        if grp_name in {'dp', 'pp'}:
-            return f([[x] for x in global_ranks[0]], local_rank, *args, **kwargs)
+        # if grp_name in {'dp', 'pp'}:
+        if grp_name in {'pp'}:
+            global_ranks = [[x] for x in global_ranks[0]]
+        
+        print (local_rank, global_ranks)
         return f(global_ranks, local_rank, *args, **kwargs)
     return _wrapper
 
@@ -196,24 +200,10 @@ class VLLMDeviceManager:
         torch.distributed.all_gather_into_tensor(output_tensors, tensor, group=self._group)
         return output_tensors.view(-1, *tensor.size()[1:])
 
-    # @property
-    # def vllm_device(self):
-    #     # NOTE: cannot handle TP for now
-    #     # this indexes into the mini-shard local to the node
-    #     local_mini_shard_index = self.local_process_index // self.mini_shard_size
-    #     # FIXME: this one is to be changed when we consider TP and local shards
-    #     return self.local_world_size + local_mini_shard_index
-
     @property
     def local_rank_mini_shard(self):
         # rank of this process within its mini shard
         return self.process_index % self.tensor_parallel
-
-    # @property
-    # def global_rank_shard_leader(self):
-    #     # the global rank of the shard leader
-    #     mini_shard_idx = self.process_index // self.mini_shard_size
-    #     return mini_shard_idx * self.mini_shard_size
 
     def group_devices(self):
         i = self.local_process_index  //  self.tensor_parallel
@@ -591,7 +581,10 @@ class GRPOTrainer(Trainer):
                     hf_overrides = {
                         'max_position_embeddings': self.max_prompt_length + self.max_completion_length
                     },
-                    max_num_seqs=self.args.per_device_train_batch_size,
+                    max_num_seqs=(
+                        self.args.per_device_train_batch_size *
+                        self.vllm_device_manager.tensor_parallel, # because of the gather
+                    ),
                     tensor_parallel_size=self.vllm_device_manager.tensor_parallel,
                     distributed_executor_backend="external_launcher",
                     enforce_eager=True, # DEBUG

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -791,8 +791,8 @@ class GRPOTrainer(Trainer):
             outputs = self.llm.generate(
                 prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
                 sampling_params=self.sampling_params, 
-                use_tqdm=False,
-                # use_tqdm=self.accelerator.is_local_main_process
+                # use_tqdm=False,
+                use_tqdm=self.accelerator.is_local_main_process
                 # use_tqdm=self.accelerator.process_index == 3
             )
             completion_ids = [

--- a/trl/trainer/grpo_trainer.py
+++ b/trl/trainer/grpo_trainer.py
@@ -117,18 +117,23 @@ from vllm.distributed.parallel_state import (
 )
 
 # To be used if VLLM is generating 
+from typing import List
 class VLLMDeviceManager:
 
     def __init__(
-        self, accelerator: Accelerator,
+        self, 
+        process_index: int,
+        local_process_index: int,
         vllm_device: str,
     ):
-        self.accelerator = accelerator
 
         # detect if we want sharding
         # new format auto:<SHARD>:<TP>
         self.mini_shards = 1
         self.tensor_parallel = 1
+        self.process_index = process_index
+        self.local_process_index = local_process_index
+        self.device = f'cuda:{process_index}'
 
         # get the local world size
         # https://pytorch.org/docs/stable/elastic/run.html#environment-variables
@@ -176,46 +181,6 @@ class VLLMDeviceManager:
                 for i in range(world_size // self.mini_shard_size)
             ]
         )
-        
-    @property
-    def is_vllm_process(self):
-        return self.rank_within_mini_shard == 0
-
-    # @property
-    # def vllm_shard_rank(self):
-    #     return self.accelerator.local_process_index // self.mini_shard_size
-
-    # @property
-    # def vllm_shard_main_process_rank(self):
-    #     return self.vllm_shard_rank * self.mini_shard_size
-    
-    # NOTE: some draft code
-    # @property
-    # def vllm_device(self):
-    #     sz = self.local_world_size + self.vllm_shard_rank * self.tensor_parallel
-    #     return [sz + i for i in range(self.tensor_parallel)]
-
-    @property
-    def vllm_device(self):
-        # NOTE: cannot handle TP for now
-        local_mini_shard = self.accelerator.local_process_index // self.mini_shard_size
-        # FIXME: this one is to be changed when we consider TP and local shards
-        return self.local_world_size + local_mini_shard
-
-    @property
-    def rank_within_mini_shard(self):
-        return self.accelerator.process_index % self.mini_shard_size
-
-    # def distributed_group(self):
-    #     return self._group
-
-    def gather_object(self, object):
-        # this follows accelerate.utils.operations.gather_object, which is an all 
-        # gather operation, used to implement the gather op here.
-        output_objects = [None for _ in range(self.mini_shard_size)]
-
-        torch.distributed.all_gather_object(output_objects, object, group=self._group)
-        return [x for y in output_objects for x in y]
 
     def gather(self, tensor):
         # this follows accelerate.utils.operations.gather, which is an all 
@@ -225,97 +190,177 @@ class VLLMDeviceManager:
             dtype=tensor.dtype,
             device=tensor.device,
         )
-        torch.distributed.barrier(
-            group=self._group, device_ids=[self.accelerator.process_index]
-        )
+        self._group_barrier()
         torch.distributed.all_gather_into_tensor(output_tensors, tensor, group=self._group)
         return output_tensors.view(-1, *tensor.size()[1:])
 
-    def gather_tensors(self, object):
-        # this follows accelerate.utils.operations.gather_object, which is an all 
-        # gather operation, used to implement the gather op here.
-        output_objects = [None for _ in range(self.mini_shard_size)]
-        device = f'cuda:{self.accelerator.process_index}'
+    @property
+    def is_vllm_process(self):
+        # essentially this is the mini shard leader
+        return self.is_shard_leader
+
+    @property
+    def vllm_device(self):
+        # NOTE: cannot handle TP for now
+        # this indexes into the mini-shard local to the node
+        local_mini_shard_index = self.local_process_index // self.mini_shard_size
+        # FIXME: this one is to be changed when we consider TP and local shards
+        return self.local_world_size + local_mini_shard_index
+
+    @property
+    def local_rank_mini_shard(self):
+        # rank of this process within its mini shard
+        return self.process_index % self.mini_shard_size
+
+    @property
+    def is_shard_leader(self):
+        return self.local_rank_mini_shard == 0
+
+    @property
+    def global_rank_shard_leader(self):
+        # the global rank of the shard leader
+        mini_shard_idx = self.process_index // self.mini_shard_size
+        return mini_shard_idx * self.mini_shard_size
+
+    def _group_barrier(self):
+        torch.distributed.barrier(
+            group=self._group, device_ids=[self.process_index]
+        )
+
+    def gather_tensor_list(self, tensors: List[torch.tensor]):
+
+        batch = len(tensors)
+        assert batch > 0, "cannot gather empty tensor list"
+        dtype = tensors[0].dtype
+
+        # assume they are all the same dtype
+        # dtype = tensors[0].dtype
+
+        # assume the tensors are 1-D
+        sizes = torch.tensor(
+            [tensors[i].shape[-1] for i in range(len(tensors))],
+            dtype=torch.int32, device=self.device
+        )
+
+        # get a single tensor
+        self._group_barrier()
+        gathered_sizes = self.gather(sizes)
+
+        # for all_gather
         output_objects = [
-            torch.empty(100, dtype=torch.int, device=device) 
-            for _ in range(self.mini_shard_size)
-    ]
+            torch.empty(
+                gathered_sizes[i*batch:(i+1)*batch].sum(),
+                dtype=dtype, device=self.device
+            )
+            for i in range(self.mini_shard_size)
+        ]
 
-        print ("rank", self.accelerator.process_index, "before barrier")
-        torch.distributed.barrier(
-            group=self._group, device_ids=[self.accelerator.process_index]
-        )
-
-        # print ("rank", self.accelerator.process_index, "after barrier")
-        # device = f'cuda:{self.accelerator.process_index}'
-        # input_slice = torch.zeros(1).cuda(device)
-        # output = torch.zeros(3).cuda(device)
-        # torch.distributed.all_gather_into_tensor(output, input_slice, group=self._group)
-        # print ("rank", self.accelerator.process_index, "after dummy gather")
-        mini_shard = self.accelerator.process_index // self.mini_shard_size
-        torch.distributed.gather(
-            torch.randint(
-                1000, (100,), device=device,
-                dtype=torch.int,
-            ),
-            (
-                output_objects if 
-                self.accelerator.process_index == mini_shard * self.mini_shard_size 
-                else None
-            ),  
+        # have to use gather because we cannot gaurantee
+        # all tensors are of equal length
+        self._group_barrier()
+        torch.distributed.all_gather(
+            output_objects,
+            torch.cat(tensors), # form batch into single tensor
             group=self._group, 
-            dst=mini_shard * self.mini_shard_size
         )
 
-        # torch.distributed.all_gather_object(output_objects, object, group=self._group)
-        # torch.distributed.all_gather_object(output_objects, ['hello'], group=self._group)
-        # mini_shard = self.accelerator.process_index // self.mini_shard_size
-        # torch.distributed.gather_object(
-        #     ['hello'], 
-        #     (
-        #         output_objects if 
-        #         self.accelerator.process_index == mini_shard * self.mini_shard_size 
-        #         else None
-        #     ),  
-        #     group=self._group, 
-        #     dst=mini_shard * self.mini_shard_size
-        # )
-        if self.accelerator.process_index == 3:
-            print (output_objects[0].sum())
-        # return [x for y in output_objects for x in y]
-        # return ['test' for y in output_objects for x in y]
-        item = '<|im_start|>system\nA conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process is enclosed within <think> </think> and the answer is given in the \\boxed environment, respectively, i.e., <think> reasoning process here </think> \\boxed{answer here}.<|im_end|>\n<|im_start|>user\nLet $\\omega = \\cos\\frac{2\\pi}{7} + i \\cdot \\sin\\frac{2\\pi}{7},$ where $i = \\sqrt{-1}.$ Find the value of the product \\[\\prod_{k=0}^6 \\left(\\omega^{3k} + \\omega^k + 1\\right).\\]<|im_end|>\n<|im_start|>assistant\nLet me solve this step by step.\n<think>', '<|im_start|>system\nA conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process is enclosed within <think> </think> and the answer is given in the \\boxed environment, respectively, i.e., <think> reasoning process here </think> \\boxed{answer here}.<|im_end|>\n<|im_start|>user\nLet $\\omega = \\cos\\frac{2\\pi}{7} + i \\cdot \\sin\\frac{2\\pi}{7},$ where $i = \\sqrt{-1}.$ Find the value of the product \\[\\prod_{k=0}^6 \\left(\\omega^{3k} + \\omega^k + 1\\right).\\]<|im_end|>\n<|im_start|>assistant\nLet me solve this step by step.\n<think>', '<|im_start|>system\nA conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process is enclosed within <think> </think> and the answer is given in the \\boxed environment, respectively, i.e., <think> reasoning process here </think> \\boxed{answer here}.<|im_end|>\n<|im_start|>user\nLet $\\omega = \\cos\\frac{2\\pi}{7} + i \\cdot \\sin\\frac{2\\pi}{7},$ where $i = \\sqrt{-1}.$ Find the value of the product \\[\\prod_{k=0}^6 \\left(\\omega^{3k} + \\omega^k + 1\\right).\\]<|im_end|>\n<|im_start|>assistant\nLet me solve this step by step.\n<think>', '<|im_start|>system\nA conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning process is enclosed within <think> </think> and the answer is given in the \\boxed environment, respectively, i.e., <think> reasoning process here </think> \\boxed{answer here}.<|im_end|>\n<|im_start|>user\nLet $\\omega = \\cos\\frac{2\\pi}{7} + i \\cdot \\sin\\frac{2\\pi}{7},$ where $i = \\sqrt{-1}.$ Find the value of the product \\[\\prod_{k=0}^6 \\left(\\omega^{3k} + \\omega^k + 1\\right).\\]<|im_end|>\n<|im_start|>assistant\nLet me solve this step by step.\n<think>'
-        return [item for _ in range(self.mini_shard_size)]
+        # pretend like its a gather
+        if not self.is_shard_leader:
+            return None
 
-    # depracated in favour of scattering
-    # def broadcast_object_list(self, object_list, device=None):
-    #     # shard_main_process_rank = self.vllm_shard_rank * self.mini_shard_size
-    #     mini_shard = torch.distributed.get_rank() // self.mini_shard_size
-    #     torch.distributed.broadcast_object_list(
-    #         object_list, src=mini_shard*self.mini_shard_size,
-    #         group=self._group
-    #     )
-    #     return object_list
+        outputs = []
+        for i in range(self.mini_shard_size):
+            batch_sizes = gathered_sizes[i*batch:(i+1)*batch].tolist()
+            outputs.extend(torch.split(
+                output_objects[i], batch_sizes,
+            ))
+        return outputs
 
-    def scatter_object_list(self, object_list, device=None):
+    def scatter_tensor_list(
+        self, 
+        batch: int,
+        dtype,
+        tensors: List[torch.tensor] = None,
+    ):
 
-        # mini_shard = torch.distributed.get_rank() // self.mini_shard_size
-        mini_shard = self.accelerator.process_index // self.mini_shard_size
-        scatter_object_output_list = [None]
-        # barrier_tensor = torch.zeros(1).cuda()
-        # torch.distributed.all_reduce(barrier_tensor, group=self._group)
+        # assume all the ranks give the same batch size
 
-        torch.distributed.barrier(
-            group=self._group, device_ids=[self.accelerator.process_index]
+        if tensors is not None:
+            assert len(tensors) > 0, "cannot scatter empty tensor list"
+            assert self.is_shard_leader, "only the shard leader can scatte"
+
+            # assume the tensors are 1-D
+            sizes = torch.tensor(
+                [tensors[i].shape[-1] for i in range(len(tensors))],
+                dtype=torch.int32, device=self.device
+            )
+        else:
+
+            # need to broadcast the sizes
+            sizes = torch.empty(
+                batch * self.mini_shard_size, 
+                dtype=torch.int32, device=self.device
+            )
+
+        # get all the sizes
+        self._group_barrier()
+        torch.distributed.broadcast(
+            sizes,
+            group=self._group, 
+            src=self.global_rank_shard_leader,
         )
-        torch.distributed.scatter_object_list(
-            scatter_object_output_list, object_list, 
-            src=mini_shard*self.mini_shard_size,
-            group=self._group
+
+        # total number of tokens in one mini shard
+        scattered_sizes_list = sizes.view(-1, batch).sum(axis=-1)
+
+        # largest number of tokens in one rank of the mini shard
+        max_size = scattered_sizes_list.max().item()
+
+        # scatter tensor
+
+        scattered_tensor = torch.empty(
+            # scattered_sizes.sum(),
+            max_size,
+            dtype=dtype, device=self.device
         )
-        # torch.cuda.synchronize()
-        return scatter_object_output_list
-# 
+
+        # each rank will get a cat of its batch
+        scattered_tensor_list = None
+        if self.is_shard_leader:
+            scattered_tensor_list = []
+            for i in range(self.mini_shard_size):
+
+                # collect all the tokens in the batch
+                # of a rank in the minishard
+                ids = []
+                for j in range(batch):
+                    ids.extend(tensors[i*batch+j])
+
+                # pad it to make all same rank
+                ids.extend([0] * (max_size - len(ids)))
+                scattered_tensor_list.append(
+                    torch.tensor(ids, dtype=dtype, device=self.device)
+                )
+
+        # get max_size tokens of the rank
+        self._group_barrier()
+        torch.distributed.scatter(
+            scattered_tensor, scattered_tensor_list,
+            group=self._group, 
+            src=self.global_rank_shard_leader,
+        )
+
+        # get the number of tokens in this rank
+        r = self.local_rank_mini_shard
+        szs_sum = scattered_sizes_list[r]
+        szs = sizes[r*batch:(r+1)*batch].tolist()
+
+        # drop the padding and split
+        outputs = torch.split(
+            scattered_tensor[:szs_sum], szs
+        )
+        return outputs
+
 class GRPOTrainer(Trainer):
     """
     Trainer for the Group Relative Policy Optimization (GRPO) method. This algorithm was initially proposed in the
@@ -588,7 +633,9 @@ class GRPOTrainer(Trainer):
             # FIXME: we need to check the generations number
 
             self.vllm_device_manager = VLLMDeviceManager(
-                self.accelerator, self.args.vllm_device
+                process_index=self.accelerator.process_index, 
+                local_process_index=self.accelerator.local_process_index, 
+                vllm_device=self.args.vllm_device
             )
 
             assert (
@@ -637,7 +684,7 @@ class GRPOTrainer(Trainer):
                         hf_overrides = {
                             'max_position_embeddings': self.max_prompt_length + self.max_completion_length
                         },
-                        enforce_eager=True, # DEBUG
+                        # enforce_eager=True, # DEBUG
                     )
                 self.sampling_params = SamplingParams(
                     temperature=args.temperature,
@@ -769,24 +816,33 @@ class GRPOTrainer(Trainer):
                 self._last_loaded_step = self.state.global_step
 
             # Generate completions using vLLM: gather all prompts and use them in a single call in the main process
-            all_prompts_text = self.vllm_device_manager.gather_object(prompts_text)
-            if self.vllm_device_manager.is_vllm_process:
-                outputs = self.llm.generate(all_prompts_text, sampling_params=self.sampling_params, use_tqdm=False)
-                completion_ids = [out.token_ids for completions in outputs for out in completions.outputs]
+            # - for safety do a plain tokenization again
+            prompts_tokens = [
+                torch.tensor(x, dtype=torch.int32, device=device)
+                for x in self.processing_class(prompts_text)['input_ids']
+            ]
+            all_prompts_ids = self.vllm_device_manager.gather_tensor_list(prompts_tokens)
+            if self.vllm_device_manager.is_vllm_process:                                              
+                outputs = self.llm.generate(
+                    prompt_token_ids=[x.tolist() for x in all_prompts_ids], 
+                    sampling_params=self.sampling_params, 
+                    use_tqdm=self.accelerator.is_local_main_process
+                    # use_tqdm=self.accelerator.process_index == 3
+                )
                 completion_ids = [
-                    completion_ids[i * len(prompts):(i+1) * len(prompts)] 
-                    for i in range(len(completion_ids) // len(prompts))
+                    torch.tensor(out.token_ids, dtype=torch.int32, device=device)
+                    for completions in outputs for out in completions.outputs
                 ]
             else:
                 completion_ids = None
 
             # Broadcast the completions from the main process to all processes, ensuring each process receives its
             # corresponding slice.
-            completion_ids = self.vllm_device_manager.scatter_object_list(completion_ids)
-            completion_ids = completion_ids[0]
+            completion_ids = self.vllm_device_manager.scatter_tensor_list(
+                tensors=completion_ids, dtype=torch.int32, batch=len(prompts),
+            )
 
             # Pad the completions, and concatenate them with the prompts
-            completion_ids = [torch.tensor(ids, device=device) for ids in completion_ids]
             completion_ids = pad(completion_ids, padding_value=self.processing_class.pad_token_id)
             prompt_completion_ids = torch.cat([prompt_ids, completion_ids], dim=1)
         else:
@@ -877,7 +933,7 @@ class GRPOTrainer(Trainer):
         advantages = (rewards - mean_grouped_rewards) / (std_grouped_rewards + 1e-4)
 
         if self.args.use_vllm:
-            process_index = self.vllm_device_manager.rank_within_mini_shard
+            process_index = self.vllm_device_manager.local_rank_mini_shard
         else:
             process_index = self.accelerator.process_index
 


### PR DESCRIPTION
To improve utilization, it is suggested to co-locate the training and vllm gpus. This PR switches to using the new external launcher 
- requires an [update to VLLM ](https://github.com/fabianlim/vllm/pull/4)to allow `DP*TP*SP` to be smaller than the world size
- switch to VLLM using the external launcher to co-locate the gpus
- allow FSDP to be used in addition to deepspeed. 
- for FSDP case, update the model in shards, without calling the full state dict to minimize peak memory

Allow extra configs
- `vllm_max_num_seqs`: to reduce kv cache size, set it optimially to number of sequences expected by vllm instance
- `vllm_num_blocks_override`: allow this to be set to reduce vllm memory usage.